### PR TITLE
Image manipulation

### DIFF
--- a/src/components/CustomHeader.tsx
+++ b/src/components/CustomHeader.tsx
@@ -39,7 +39,7 @@ export default class CustomHeader extends React.Component<CustomHeaderProps> {
     transparent: false,
   }
   render() {
-    const curIssue = 'spring25'
+    const curIssue = 'summer25'
     const background = this.props.transparent ? transparent : black
     const headerStyle = css`
       width: 100%;

--- a/src/components/smallImageC.tsx
+++ b/src/components/smallImageC.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import { css } from 'react-emotion'
+
+const imageStyle = css`
+  display: flex;
+  flex-direction: column;
+  font-family: Barlow;
+  padding: 0;
+  border: none;
+  float: none;
+  width: 50%;
+  line-height: normal;
+  margin: 0 auto 1rem auto;
+  @media screen and (max-width: 808px) {
+  }
+`
+interface ImageProps {
+    url: string
+    caption: string
+    credit: string
+    alt: string
+    /** Custom css for the image component */
+    style?: string
+}
+
+export class CustomSmallImageC extends React.Component<ImageProps> {
+    render() {
+        return (
+            <figure className={imageStyle}>
+                <img
+                    className={css`
+            margin-bottom: 0;
+          `}
+                    src={this.props.url}
+                    alt={this.props.alt}
+                />
+                <figcaption>
+                    {this.props.caption} ({this.props.credit})
+                </figcaption>
+            </figure>
+        )
+    }
+}

--- a/src/components/smallImageL.tsx
+++ b/src/components/smallImageL.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { css } from 'react-emotion'
+
+const imageStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  font-family: Barlow;
+  padding: 0;
+  border: none;
+  float: left;
+  width: 50%;
+  line-height: normal;
+  margin:  0.5rem 0.5rem 0 -50px;
+  @media screen and (max-width: 808px) {
+    margin: 0.5rem 0.5rem 0 0;
+  }
+`
+interface ImageProps {
+    url: string
+    caption: string
+    credit: string
+    alt: string
+    /** Custom css for the image component */
+    style?: string
+}
+
+export class CustomSmallImageL extends React.Component<ImageProps> {
+    render() {
+        return (
+            <figure className={imageStyle}>
+                <img
+                    className={css`
+            margin-bottom: 0;
+          `}
+                    src={this.props.url}
+                    alt={this.props.alt}
+                />
+                <figcaption>
+                    {this.props.caption} ({this.props.credit})
+                </figcaption>
+            </figure>
+        )
+    }
+}

--- a/src/components/smallImageR.tsx
+++ b/src/components/smallImageR.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { css } from 'react-emotion'
+
+const imageStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-family: Barlow;
+  padding: 0;
+  border: none;
+  float: right;
+  width: 50%;
+  line-height: normal;
+  margin: 0.5rem -100px 0 0.5rem;
+  @media screen and (max-width: 808px) {
+    margin: 0.5rem 0 0 0.5rem;
+  }
+`
+interface ImageProps {
+    url: string
+    caption: string
+    credit: string
+    alt: string
+    /** Custom css for the image component */
+    style?: string
+}
+
+export class CustomSmallImageR extends React.Component<ImageProps> {
+    render() {
+        return (
+            <figure className={imageStyle}>
+                <img
+                    className={css`
+            margin-bottom: 0;
+          `}
+                    src={this.props.url}
+                    alt={this.props.alt}
+                />
+                <figcaption>
+                    {this.props.caption} ({this.props.credit})
+                </figcaption>
+            </figure>
+        )
+    }
+}

--- a/src/templates/article.tsx
+++ b/src/templates/article.tsx
@@ -10,6 +10,9 @@ import { HeaderHighLight } from '../components/TripleHeader/HeaderHighLight'
 import { StyledCoverPhoto } from '../components/StyledCoverPhoto'
 import { FooterAuthorBio } from '../components/FooterAuthorBio'
 import { CustomPullImage } from '../components/pullImage'
+import { CustomSmallImageR } from '../components/smallImageR'
+import { CustomSmallImageL } from '../components/smallImageL'
+import { CustomSmallImageC } from '../components/smallImageC'
 import { CustomPullQuote } from '../components/pullQuote'
 
 export const query = graphql`
@@ -60,8 +63,8 @@ export default ({ data, pageContext }) => {
             !data.primeArticle.slug
               ? ''
               : `https://prime.dailybruin.com/${data.primeArticle.slug
-                  .split('.')
-                  .join('')}`
+                .split('.')
+                .join('')}`
           }
           image={data.primeArticle.coverimg}
         >
@@ -77,6 +80,18 @@ export default ({ data, pageContext }) => {
   const year = '20' + term.substring(term.length - 2, term.length)
   const formatTerm = season + ' ' + year
 
+  const imageTypes = ['smallimageR', 'smallimageL', 'smallimageC']
+  let i = 0
+  for (const content of data.primeArticle.content) {
+    if (content.type === 'image') {
+        content.type = imageTypes[i]
+        i++
+    }
+    if (i === 3) {
+      break
+    }
+  }
+
   // Client Side Rendering = when the browser renders the page, this version will be seen.
   return (
     <div>
@@ -88,11 +103,11 @@ export default ({ data, pageContext }) => {
           !data.primeArticle.slug
             ? ''
             : `https://prime.dailybruin.com/${data.primeArticle.slug
-                .split('.')
-                .join('')}`
+              .split('.')
+              .join('')}`
         }
         image={data.primeArticle.coverimg}
-        >
+      >
         {/* Added because this person wants her article de-indexed. It should add a tag only for this article. */}
         {(data.primeArticle.headline === "The Fundamental Difference") && (data.primeArticle.author === "Genevieve Finn") && <meta name="robots" content="noindex, nofollow" />}
       </CustomHead>
@@ -110,20 +125,23 @@ export default ({ data, pageContext }) => {
       {data.primeArticle.articleType === 'graphic' && (
         <GraphicNovel content={data.primeArticle.content} />
       )}
+      {console.log(data.primeArticle)}
       {data.primeArticle.articleType === 'article' && (
         <>
-        <p style={{"text-align":"center", "font-family": 'Source Serif Pro'}}> {data.primeArticle.updated}</p>
-        <Article
-          dropcap={true}
-          content={data.primeArticle.content}
-          customTypeComponentMapping={{
-            pull: CustomPullQuote,
-            pullimage: CustomPullImage,
-            subheading: Subheading,
-            italics: Italics,
-            video: Video,
-          }}
-          style={css`
+          <p style={{ "text-align": "center", "font-family": 'Source Serif Pro' }}> {data.primeArticle.updated}</p>
+          <Article
+            dropcap={true}
+            content={data.primeArticle.content}
+            customTypeComponentMapping={{
+              pull: CustomPullQuote,
+              smallimageR: CustomSmallImageR,
+              smallimageL: CustomSmallImageL,
+              smallimageC: CustomSmallImageC,
+              subheading: Subheading,
+              italics: Italics,
+              video: Video,
+            }}
+            style={css`
             max-width: 60%;
             font-family: 'Source Serif Pro';
             line-height: 38px;
@@ -131,13 +149,13 @@ export default ({ data, pageContext }) => {
             min-width: 300px;
             figcaption {
               font-style: italic;
-              font-size: 1.15rem;
+              font-size: 1rem;
             }
             @media only screen and (max-width: 800px) {
               max-width: 80%;
             }
           `}
-        />
+          />
         </>
       )}
       <FooterAuthorBio


### PR DESCRIPTION
<img width="435" height="171" alt="Screenshot 2026-02-03 at 10 25 19 PM" src="https://github.com/user-attachments/assets/002d4558-5c90-4524-a96d-5831d66e2665" />

The code shown above is inside article.tsx, and it just manually shows how the small images look when they're oriented to the right, left and center. Just goto any article and the first 3 images in the article will be oriented in the said order. 
I added 3 new types of images for article writers to specify for their image in the AML: "smallimageR", "smallimageL", and "smallimageC", which is oriented right, left, and center respectively. Large images should continue following the same type, which was just "image". These names can of course be changed if they want.

So for production when the AMLs incorporate the new types, that code snippet should be deleted.

Below is how it looks like right now.


<img width="690" height="563" alt="Screenshot 2026-02-03 at 10 38 07 PM" src="https://github.com/user-attachments/assets/b6404be5-c2de-464c-8785-329ea2e4d052" />
<img width="651" height="527" alt="Screenshot 2026-02-03 at 10 38 13 PM" src="https://github.com/user-attachments/assets/865b9774-d0da-4394-ad44-bfc17316b902" />
<img width="583" height="592" alt="Screenshot 2026-02-03 at 10 38 26 PM" src="https://github.com/user-attachments/assets/19f5b9d6-2329-490c-ada1-90c07896f1f3" />
